### PR TITLE
Adding support for token copy to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ armclient is just one binary, you can copy it to whereever you want and use it.
 
 For Linux (I only tested Ubuntu):
 ```bash
-curl -sL https://github.com/yangl900/armclient-go/releases/download/v0.2.0/armclient-go_0.2.0_linux_64-bit.tar.gz | tar xz
+curl -sL https://github.com/yangl900/armclient-go/releases/download/v0.2.1/armclient-go_0.2.1_linux_64-bit.tar.gz | tar xz
 ```
 
 For Windows (In PowerShell):
 ```powershell
-curl https://github.com/yangl900/armclient-go/releases/download/v0.2.0/armclient-go_0.2.0_windows_64-
+curl https://github.com/yangl900/armclient-go/releases/download/v0.2.1/armclient-go_0.2.1_windows_64-
 bit.tar.gz -OutFile armclient.tar.gz
 ```
 And unzip the tar.gz file, only binary needed is armclient.exe
@@ -29,10 +29,14 @@ And unzip the tar.gz file, only binary needed is armclient.exe
 For MacOS:
 Download and unzip
 ```
-https://github.com/yangl900/armclient-go/releases/download/v0.2.0/armclient-go_0.2.0_macOS_64-bit.tar.gz
+https://github.com/yangl900/armclient-go/releases/download/v0.2.1/armclient-go_0.2.1_macOS_64-bit.tar.gz
 ```
 
-I did NOT test, if anyone made it working please let me know:)
+Alternatively for mac you can run the following in bash.
+
+```bash
+curl -sL https://github.com/yangl900/armclient-go/releases/download/v0.2.1/armclient-go_0.2.1_macOS_64-bit.tar.gz | tar xz
+```
 
 # How to use it
 It's very straight-forward. Syntax is exactly same as original ARMClient. To *GET* your subscriptions, simply do

--- a/armclient.go
+++ b/armclient.go
@@ -14,10 +14,11 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/urfave/cli"
+	"github.com/atotto/clipboard"
 )
 
 const (
-	appVersion   = "0.2"
+	appVersion   = "0.21"
 	userAgentStr = "github.com/yangl900/armclient-go"
 	flagVerbose  = "verbose"
 	flagRaw      = "raw, r"
@@ -187,6 +188,7 @@ func printToken(c *cli.Context) error {
 
 	if c.Bool(strings.Split(flagRaw, ",")[0]) {
 		fmt.Println(token)
+		clipboard.WriteAll(token)
 	} else {
 		segments := strings.Split(token, ".")
 
@@ -197,6 +199,9 @@ func printToken(c *cli.Context) error {
 		decoded, _ := jwt.DecodeSegment(segments[1])
 
 		fmt.Println(prettyJSON(decoded))
+
+		clipboard.WriteAll(token)
+		fmt.Println("\n\nToken copied to clipboard successfully.")
 	}
 
 	return nil

--- a/armclient.go
+++ b/armclient.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	appVersion   = "0.21"
+	appVersion   = "0.2.1"
 	userAgentStr = "github.com/yangl900/armclient-go"
 	flagVerbose  = "verbose"
 	flagRaw      = "raw, r"


### PR DESCRIPTION
Similar to [projectkudu/armclient](https://github.com/projectkudu/ARMClient/blob/39669e82921ad6279d7383a9ddaa526187598ae4/ARMClient.Console/Program.cs#L108-L112) adding support to copy the bearer token to clipboard.

Also updated the README as I did confirm this works with Mac OS 👍 